### PR TITLE
add support for nektro/zigmod package manager

### DIFF
--- a/zig.mod
+++ b/zig.mod
@@ -1,6 +1,6 @@
 id: hm449ur2xup4lnud5ghn0pdkbtk7uy5111nagqu84cuu5yh0
 name: apple_pie
-main: src/main.zig
+main: src/apple_pie.zig
 dependencies:
 - type: git
   path: https://github.com/lithdew/pike

--- a/zig.mod
+++ b/zig.mod
@@ -1,0 +1,9 @@
+id: hm449ur2xup4lnud5ghn0pdkbtk7uy5111nagqu84cuu5yh0
+name: apple_pie
+main: src/main.zig
+dependencies:
+- type: git
+  path: https://github.com/lithdew/pike
+- type: git
+  path: https://github.com/kprotty/zap
+  version: branch-ziggo


### PR DESCRIPTION
merging this pull request would allow the removal of the use of git submodules.