### PR TITLE
Print out error return trace on error

### DIFF
--- a/src/server.zig
+++ b/src/server.zig
@@ -130,6 +130,9 @@ fn ClientFn(comptime handler: RequestHandler) type {
         fn run(self: *Self, gpa: *Allocator, clients: *Queue(*Self)) void {
             self.handle(gpa, clients) catch |err| {
                 log.err("An error occured handling request: '{s}'", .{@errorName(err)});
+                if (@errorReturnTrace()) |trace| {
+                    std.debug.dumpStackTrace(trace.*);
+                }
             };
         }
 


### PR DESCRIPTION
I copied the code for printing out an  error return trace from `lib/std/start.zig`. Makes debugging errors a bit easier.