### PR TITLE
Ensure all headers are read

### DIFF
--- a/src/server.zig
+++ b/src/server.zig
@@ -26,6 +26,9 @@ const Client = struct {
     fn run(server: *Server, notifier: *const pike.Notifier, socket: pike.Socket, address: net.Address) void {
         inlineRun(server, notifier, socket, address) catch |err| {
             log.err("An error occured while handling a request: {}", .{@errorName(err)});
+            if (@errorReturnTrace()) |trace| {
+                std.debug.dumpStackTrace(trace.*);
+            }
         };
     }
 


### PR DESCRIPTION
This is marked as a draft because I implemented this is in a hackish way.

It works by swapping out the single call to `reader.read` for reading one byte at a time until we find the double `\r\n` sequence that marks the end of the headers.

Would close #15 