### PR TITLE
more fs fixes

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -101,7 +101,7 @@ pub fn serveFile(
         return error.NotAFile;
 
     response.is_flushed = true;
-    var stream = response.writer();
+    var stream = response.buffered_writer.unbuffered_writer;
     const len = stat.size;
 
     // write status line
@@ -121,9 +121,8 @@ pub fn serveFile(
 
     //Carrot Return after headers to tell clients where headers end, and body starts
     try stream.writeAll("\r\n");
-    try response.flush();
 
-    const out = response.buffered_writer.unbuffered_writer.context.handle;
+    const out = stream.context.handle;
     var remaining: u64 = len;
     while (remaining > 0) {
         remaining -= try std.os.sendfile(out, file.handle, len - remaining, remaining, &.{}, &.{}, 0);

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -101,7 +101,7 @@ pub fn serveFile(
         return error.NotAFile;
 
     response.is_flushed = true;
-    var stream = response.buffered_writer.unbuffered_writer;
+    var stream = response.buffered_writer.writer();
     const len = stat.size;
 
     // write status line
@@ -121,8 +121,9 @@ pub fn serveFile(
 
     //Carrot Return after headers to tell clients where headers end, and body starts
     try stream.writeAll("\r\n");
+    try response.buffered_writer.flush();
 
-    const out = stream.context.handle;
+    const out = response.buffered_writer.unbuffered_writer.context.handle;
     var remaining: u64 = len;
     while (remaining > 0) {
         remaining -= try std.os.sendfile(out, file.handle, len - remaining, remaining, &.{}, &.{}, 0);


### PR DESCRIPTION
the file server needs to write raw headers and then sendfile directly to a file writer, this gets the file writer from the response's buffered writer and removes an uneeded flush that ended up sending two sets of http headers