### PR TITLE
properly handle request bodies smaller than buffer

### DIFF
--- a/src/request.zig
+++ b/src/request.zig
@@ -279,7 +279,15 @@ pub fn parse(gpa: *Allocator, reader: anytype, buffer: []u8) (ParseError || @Typ
                     request.body = buffer[i .. i + length];
                 } else {
                     const body = try gpa.alloc(u8, length);
-                    std.mem.copy(u8, body, buffer[i..]);
+
+                    // if the body is less than the buffer, try to fill in
+                    // from it, and still read more, else, copy the entire
+                    // buffer into working body
+                    if (length < buffer.len) {
+                        std.mem.copy(u8, body, buffer[i..(i + length)]);
+                    } else {
+                        std.mem.copy(u8, body, buffer[i..]);
+                    }
                     var index: usize = read - i;
                     while (index < body.len) {
                         index += try reader.read(body[index..]);


### PR DESCRIPTION
For context, this is the crash I've got when uploading a small file (<4KB):

```
thread 14705 panic: reached unreachable code
/usr/lib/zig/std/debug.zig:223:14: 0x20d87b in std.debug.assert (yet-another-pomf-clone)
    if (!ok) unreachable; // assertion failure
             ^
/usr/lib/zig/std/mem.zig:157:11: 0x21b204 in std.mem.copy (yet-another-pomf-clone)
    assert(dest.len >= source.len);
          ^
/home/luna/git/yet-another-pomf-clone/.zigmod/deps/git/github.com/lun-4/apple_pie/src/request.zig:282:33: 0x2549e8 in .apple_pie.request.parse (yet-another-pomf-clone)
                    std.mem.copy(u8, body, buffer[i..]);
                                ^
/home/luna/git/yet-another-pomf-clone/.zigmod/deps/git/github.com/lun-4/apple_pie/src/server.zig:162:49: 0x251b32 in .apple_pie.server.ClientFn(.apple_pie.router.router([]const .apple_pie.router.Route{(struct .apple_pie.router.Route constant),(struct .apple_pie.router.Route constant),(struct .apple_pie.router.Route constant)}).serve).handle (yet-another-pomf-clone)
                const parsed_request = req.parse(
                                                ^

---snip---
```