### PR TITLE
breaking: New parsing structure

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -41,7 +41,7 @@ pub fn build(b: *Builder) void {
         var example = b.addExecutable(opt, example_file);
         example.addPackage(.{
             .name = "apple_pie",
-            .path = "src/apple_pie.zig",
+            .path = .{ .path = "src/apple_pie.zig" },
         });
         example.setBuildMode(mode);
         example.install();

--- a/examples/router.zig
+++ b/examples/router.zig
@@ -16,7 +16,7 @@ pub fn main() !void {
     try http.listenAndServe(
         allocator,
         try std.net.Address.parseIp("127.0.0.1", 8080),
-        comptime router.router(&[_]router.Route{
+        comptime router.router(&.{
             router.get("/", index),
             router.get("/headers", headers),
             router.get("/files/*", serveFs),
@@ -33,7 +33,7 @@ fn index(response: *http.Response, request: http.Request) !void {
 }
 
 fn headers(response: *http.Response, request: http.Request) !void {
-    try response.writer().print("Path: {s}\n", .{request.url.path});
+    try response.writer().print("Path: {s}\n", .{request.context.url.path});
     var it = request.iterator();
     while (it.next()) |header| {
         try response.writer().print("{s}: {s}\n", .{ header.key, header.value });

--- a/examples/router.zig
+++ b/examples/router.zig
@@ -33,7 +33,7 @@ fn index(response: *http.Response, request: http.Request) !void {
 }
 
 fn headers(response: *http.Response, request: http.Request) !void {
-    try response.writer().print("Path: {s}\n", .{request.context.url.path});
+    try response.writer().print("Path: {s}\n", .{request.path()});
     var it = request.iterator();
     while (it.next()) |header| {
         try response.writer().print("{s}: {s}\n", .{ header.key, header.value });

--- a/src/Request.zig
+++ b/src/Request.zig
@@ -233,17 +233,16 @@ pub const ParseError = error{
     InvalidBody,
 };
 
-var default_body_read_value = false;
 /// Parse accepts a `Stream`. It will read all data it contains
 /// and tries to parse it into a `Request`. Can return `ParseError` if data is corrupt
 /// The memory of the `Request` is owned by the caller and can be freed by using deinit()
 /// `buffer_size` is the size that is allocated to parse the request line and headers, any headers
 /// bigger than this size will be skipped.
-pub fn parse(gpa: *Allocator, reader: *Reader, buffer: []u8) (ParseError || Stream.ReadError)!Request {
+pub fn parse(body_read: *bool, gpa: *Allocator, reader: *Reader, buffer: []u8) (ParseError || Stream.ReadError)!Request {
     return Request{
         .arena = gpa,
         .reader = reader,
-        .body_read = &default_body_read_value,
+        .body_read = body_read,
         .context = try parseContext(
             reader.reader(),
             buffer,

--- a/src/Request.zig
+++ b/src/Request.zig
@@ -3,140 +3,195 @@ const Url = @import("url.zig").Url;
 const Allocator = std.mem.Allocator;
 const mem = std.mem;
 
-/// Represents a request made by a client
-pub const Request = struct {
-    /// HTTP methods as specified in RFC 7231
-    pub const Method = enum {
-        get,
-        head,
-        post,
-        put,
-        delete,
-        connect,
-        options,
-        trace,
-        patch,
-        any,
+const Request = @This();
 
-        fn fromString(method: []const u8) Method {
-            return switch (method[0]) {
-                'G' => .get,
-                'H' => .head,
-                'P' => @as(Method, switch (method[1]) {
-                    'O' => .post,
-                    'U' => .put,
-                    else => .patch,
-                }),
-                'D' => .delete,
-                'C' => .connect,
-                'O' => .options,
-                'T' => .trace,
-                else => .any,
-            };
-        }
-    };
+/// GET, POST, PUT, DELETE or PATCH
+method: Method,
+/// Url object, get be used to retrieve path or query parameters
+url: Url,
+/// HTTP Request headers data.
+raw_header_data: []const u8,
+/// Protocol used by the requester, http1.1, http2.0, etc.
+protocol: Protocol,
+/// Length of requests body
+content_length: usize,
+/// True if http protocol version 1.0 or invalid request
+should_close: bool,
+/// Hostname the request was sent to. Includes its port. Required for HTTP/1.1
+/// Cannot be null for user when `protocol` is `http1_1`.
+host: ?[]const u8,
+/// Internal allocator, fed by an arena allocator. Any memory allocated using this
+/// allocator will be freed upon the end of a request. It's therefore illegal behaviour
+/// to read from/write to its memory after a request and must be duplicated first.
+arena: *Allocator,
+/// `std.io.Reader` for the current request. Saved and used to retrieve the body of
+/// a request when content length != 0. Using this reader directly outside the helper
+/// functions such as `bufferedBody` and `body` may cause unwanted side-effects.
+reader: AnyReader,
 
-    /// HTTP Protocol version
-    pub const Protocol = enum {
-        http1_0,
-        http1_1,
-        http2_0,
+/// HTTP methods as specified in RFC 7231
+pub const Method = enum {
+    get,
+    head,
+    post,
+    put,
+    delete,
+    connect,
+    options,
+    trace,
+    patch,
+    any,
 
-        /// Checks the given string and gives its protocol version
-        /// Defaults to HTTP/1.1
-        fn fromString(protocol: []const u8) Protocol {
-            const eql = std.mem.eql;
-            if (eql(u8, protocol, "HTTP/1.1")) return .http1_1;
-            if (eql(u8, protocol, "HTTP/2.0")) return .http2_0;
-            if (eql(u8, protocol, "HTTP/1.0")) return .http1_0;
+    fn fromString(method: []const u8) Method {
+        return switch (method[0]) {
+            'G' => .get,
+            'H' => .head,
+            'P' => @as(Method, switch (method[1]) {
+                'O' => .post,
+                'U' => .put,
+                else => .patch,
+            }),
+            'D' => .delete,
+            'C' => .connect,
+            'O' => .options,
+            'T' => .trace,
+            else => .any,
+        };
+    }
+};
 
-            return .http1_1;
-        }
-    };
+/// HTTP Protocol version
+pub const Protocol = enum {
+    http_0_9,
+    http_1_0,
+    http_1_1,
+    http_2_0,
 
-    /// Represents an HTTP Header
-    pub const Header = struct {
-        key: []const u8,
-        value: []const u8,
-    };
+    /// Checks the given string and gives its protocol version
+    /// Defaults to HTTP/1.1
+    fn fromString(protocol: []const u8) Protocol {
+        const eql = std.mem.eql;
+        if (eql(u8, protocol, "HTTP/1.1")) return .http_1_1;
+        if (eql(u8, protocol, "HTTP/2.0")) return .http_2_0;
+        if (eql(u8, protocol, "HTTP/1.0")) return .http_1_0;
+        if (eql(u8, protocol, "HTTP/0.9")) return .http_0_9;
 
-    /// Alias to StringHashMapUnmanaged([]const u8)
-    pub const Headers = std.StringHashMapUnmanaged([]const u8);
+        return .http_1_1; // default
+    }
+};
 
-    /// GET, POST, PUT, DELETE or PATCH
-    method: Method,
-    /// Url object, get be used to retrieve path or query parameters
-    url: Url,
-    /// HTTP Request headers data.
-    raw_header_data: []const u8,
-    /// Body, which can be empty
-    body: []const u8,
-    /// Protocol used by the requester, http1.1, http2.0, etc.
-    protocol: Protocol,
-    /// Length of requests body
-    content_length: usize,
-    /// True if http protocol version 1.0 or invalid request
-    should_close: bool,
-    /// Hostname the request was sent to. Includes its port. Required for HTTP/1.1
-    /// Cannot be null for user when `protocol` is `http1_1`.
-    host: ?[]const u8,
+/// Represents an HTTP Header
+pub const Header = struct {
+    key: []const u8,
+    value: []const u8,
+};
 
-    /// Iterator to iterate through headers
-    const Iterator = struct {
-        slice: []const u8,
-        index: usize,
+/// Alias to StringHashMapUnmanaged([]const u8)
+pub const Headers = std.StringHashMapUnmanaged([]const u8);
 
-        /// Searches for the next header.
-        /// Parsing cannot be failed as that would have been caught by `parse()`
-        pub fn next(self: *Iterator) ?Header {
-            if (self.index >= self.slice.len) return null;
+/// Wrapper struct around any given reader.
+/// This will allow us to store any kind of reader without creating a generic
+/// or having it be comptime.
+const AnyReader = struct {
+    const InnerType = opaque {};
+    inner: *const InnerType,
+    read_fn: fn (self: *const InnerType, buf: []u8) callconv(.Async) anyerror!usize,
 
-            var state: enum { key, value } = .key;
-
-            var header: Header = undefined;
-            var start = self.index;
-            while (self.index < self.slice.len) : (self.index += 1) {
-                const c = self.slice[self.index];
-                if (state == .key and c == ':') {
-                    header.key = self.slice[start..self.index];
-                    start = self.index + 2;
-                    state = .value;
+    fn init(reader: anytype) AnyReader {
+        const T = std.meta.Child(@TypeOf(reader));
+        return .{
+            .inner = @ptrCast(*const InnerType, reader),
+            .read_fn = struct {
+                fn read(self: *const InnerType, buf: []u8) callconv(.Async) anyerror!usize {
+                    return @ptrCast(*const T, @alignCast(@alignOf(T), self)).read(buf);
                 }
-                if (state == .value and c == '\r') {
-                    header.value = self.slice[start..self.index];
-                    self.index += 2;
-                    return header;
-                }
-            }
-
-            return null;
-        }
-    };
-
-    /// Creates an iterator to retrieve all headers
-    /// As the data is known, this does not require any allocations
-    /// If all headers needs to be known at once, use `headers()`.
-    pub fn iterator(self: Request) Iterator {
-        return Iterator{
-            .slice = self.raw_header_data[0..],
-            .index = 0,
+            }.read,
         };
     }
 
-    /// Creates an unmanaged Hashmap from the request headers, memory is owned by caller
-    /// Every header key and value will be allocated for the map and must therefore be freed
-    /// manually as well.
-    pub fn headers(self: Request, allocator: *std.mem.Allocator) !Headers {
-        var map = Headers{};
-
-        var it = self.iterator();
-        while (it.next()) |header| {
-            try map.put(allocator, try allocator.dupe(u8, header.key), try allocator.dupe(u8, header.value));
-        }
-
-        return map;
+    fn read(self: AnyReader, buffer: []u8) anyerror!usize {
+        return self.read_fn(self.inner, buffer);
     }
 };
+
+/// Iterator to iterate through headers
+const Iterator = struct {
+    slice: []const u8,
+    index: usize,
+
+    /// Searches for the next header.
+    /// Parsing cannot be failed as that would have been caught by `parse()`
+    pub fn next(self: *Iterator) ?Header {
+        if (self.index >= self.slice.len) return null;
+
+        var state: enum { key, value } = .key;
+
+        var header: Header = undefined;
+        var start = self.index;
+        while (self.index < self.slice.len) : (self.index += 1) {
+            const c = self.slice[self.index];
+            if (state == .key and c == ':') {
+                header.key = self.slice[start..self.index];
+                start = self.index + 2;
+                state = .value;
+            }
+            if (state == .value and c == '\r') {
+                header.value = self.slice[start..self.index];
+                self.index += 2;
+                return header;
+            }
+        }
+
+        return null;
+    }
+};
+
+/// Creates an iterator to retrieve all headers
+/// As the data is known, this does not require any allocations
+/// If all headers needs to be known at once, use `headers()`.
+pub fn iterator(self: Request) Iterator {
+    return Iterator{
+        .slice = self.raw_header_data[0..],
+        .index = 0,
+    };
+}
+
+/// Creates an unmanaged Hashmap from the request headers, memory is owned by caller
+/// Every header key and value will be allocated for the map and must therefore be freed
+/// manually as well.
+pub fn headers(self: Request, gpa: *Allocator) !Headers {
+    var map = Headers{};
+
+    var it = self.iterator();
+    while (it.next()) |header| {
+        try map.put(gpa, try gpa.dupe(u8, header.key), try gpa.dupe(u8, header.value));
+    }
+
+    return map;
+}
+
+/// Parses the body of the request and allocates the contents inside a buffer.
+/// Memory must be handled manually by the caller
+pub fn body(self: Request, gpa: *Allocator) ![]const u8 {
+    if (self.content_length == 0) return "";
+    const buffer = try gpa.alloc(u8, self.content_length);
+    var i: usize = 0;
+    while (i < self.content_length) {
+        const len = try self.reader.read(buffer[i..]);
+        if (len == 0) return error.EndOfStream;
+        i += len;
+    }
+    return buffer;
+}
+
+/// Reads the body of a request into the given `buffer`
+/// Returns the length that was written to the buffer.
+/// Asserts `buffer` has a size bigger than 0.
+pub fn bufferedBody(self: Request, buffer: []u8) !usize {
+    std.debug.assert(buffer.len > 0);
+    const min = std.math.min(self.content_length, buffer.len);
+    return self.reader.read(buffer[0..min]);
+}
 
 /// Errors which can occur during the parsing of
 /// a HTTP request.
@@ -176,7 +231,6 @@ pub const ParseError = error{
 /// bigger than this size will be skipped.
 pub fn parse(gpa: *Allocator, reader: anytype, buffer: []u8) (ParseError || @TypeOf(reader).Error)!Request {
     var request: Request = .{
-        .body = "",
         .method = .get,
         .url = Url{
             .path = "/",
@@ -184,13 +238,15 @@ pub fn parse(gpa: *Allocator, reader: anytype, buffer: []u8) (ParseError || @Typ
             .raw_query = "",
         },
         .raw_header_data = undefined,
-        .protocol = .http1_1,
+        .protocol = .http_1_1,
         .content_length = 0,
         .should_close = false,
         .host = null,
+        .arena = gpa,
+        .reader = AnyReader.init(&reader),
     };
 
-    var parser = Parser(@TypeOf(reader)).init(gpa, buffer, reader);
+    var parser = Parser(@TypeOf(reader)).init(buffer, reader);
     while (parser.nextEvent()) |ev| {
         const event = ev orelse break;
 
@@ -201,15 +257,13 @@ pub fn parse(gpa: *Allocator, reader: anytype, buffer: []u8) (ParseError || @Typ
                 request.method = Request.Method.fromString(status.method);
             },
             .header => |header| {
-                if (request.protocol != .http1_0 and !request.should_close and std.ascii.eqlIgnoreCase(header.key, "connection")) {
+                if (request.protocol != .http_1_0 and !request.should_close and std.ascii.eqlIgnoreCase(header.key, "connection")) {
                     if (std.ascii.eqlIgnoreCase(header.value, "close")) request.should_close = true;
                 }
 
                 if (request.host == null and std.ascii.eqlIgnoreCase(header.key, "host"))
                     request.host = header.value;
             },
-            .body => |body| request.body = body,
-            .skip => {},
         }
     } else |err| switch (err) {
         else => |e| return e,
@@ -226,7 +280,6 @@ fn Parser(ReaderType: anytype) type {
 
         buffer: []u8,
         index: usize,
-        gpa: *Allocator,
         state: std.meta.Tag(Event),
         reader: ReaderType,
         done: bool,
@@ -244,17 +297,14 @@ fn Parser(ReaderType: anytype) type {
                 key: []const u8,
                 value: []const u8,
             },
-            body: []const u8,
-            skip: void,
         };
 
         const Error = ParseError || ReaderType.Error;
 
-        fn init(gpa: *Allocator, buffer: []u8, reader: ReaderType) Self {
+        fn init(buffer: []u8, reader: ReaderType) Self {
             return .{
                 .buffer = buffer,
                 .reader = reader,
-                .gpa = gpa,
                 .state = .status,
                 .index = 0,
                 .done = false,
@@ -270,8 +320,6 @@ fn Parser(ReaderType: anytype) type {
             return switch (self.state) {
                 .status => self.parseStatus(),
                 .header => self.parseHeader(),
-                .body => self.parseBody(),
-                .skip => unreachable,
             };
         }
 
@@ -298,11 +346,10 @@ fn Parser(ReaderType: anytype) type {
         fn parseHeader(self: *Self) Error!?Event {
             const line = (try self.reader.readUntilDelimiterOrEof(self.buffer[self.index..], '\n')) orelse return ParseError.EndOfStream;
             self.index += line.len + 1;
-            if (line.len == 1) {
-                if (self.content_length == 0) self.done = true;
-                self.state = .body;
+            if (line.len == 1 and line[0] == '\r') {
+                self.done = true;
                 self.header_end = self.index;
-                return Event.skip;
+                return null;
             }
             var it = mem.tokenize(try assertLE(line), " ");
 
@@ -320,27 +367,8 @@ fn Parser(ReaderType: anytype) type {
             };
         }
 
-        fn parseBody(self: *Self) Error!?Event {
-            self.done = true;
-            const length = self.content_length;
-
-            // if body fit inside the buffer, we use that,
-            // else allocate more memory
-            if (length <= self.buffer.len - self.index) {
-                const read = try self.reader.readAll(self.buffer[self.index..]);
-                if (read < length) return ParseError.InvalidBody;
-                return Event{
-                    .body = self.buffer[self.index .. self.index + read],
-                };
-            } else {
-                const body = try self.gpa.alloc(u8, length);
-                const read = try self.reader.readAll(body);
-                if (read < length) return ParseError.InvalidBody;
-                return Event{ .body = body };
-            }
-        }
-
         fn assertLE(line: []const u8) ParseError![]const u8 {
+            if (line.len == 0) return ParseError.InvalidLineEnding;
             const idx = line.len - 1;
             if (line[idx] != '\r') return ParseError.InvalidLineEnding;
 
@@ -372,31 +400,31 @@ test "Basic request parse" {
     var request = try parse(&arena.allocator, stream, &buf);
 
     std.testing.expectEqualStrings("/test", request.url.path);
-    std.testing.expectEqual(Request.Protocol.http1_1, request.protocol);
+    std.testing.expectEqual(Request.Protocol.http_1_1, request.protocol);
     std.testing.expectEqual(Request.Method.get, request.method);
-    std.testing.expectEqualStrings("some body", request.body);
+    std.testing.expectEqualStrings("some body", try request.body(&arena.allocator));
 
-    var headers = try request.headers(std.testing.allocator);
+    var _headers = try request.headers(std.testing.allocator);
     defer {
-        var it = headers.iterator();
+        var it = _headers.iterator();
         while (it.next()) |header| {
             std.testing.allocator.free(header.key);
             std.testing.allocator.free(header.value);
         }
-        headers.deinit(std.testing.allocator);
+        _headers.deinit(std.testing.allocator);
     }
 
-    std.testing.expect(headers.contains("Host"));
-    std.testing.expect(headers.contains("Accept"));
+    std.testing.expect(_headers.contains("Host"));
+    std.testing.expect(_headers.contains("Accept"));
 }
 
 test "Request iterator" {
-    const headers = "User-Agent: ApplePieClient/1\r\n" ++
+    const _headers = "User-Agent: ApplePieClient/1\r\n" ++
         "Accept: application/json\r\n" ++
         "content-Length: 0\r\n";
 
     var it = Request.Iterator{
-        .slice = headers,
+        .slice = _headers,
         .index = 0,
     };
     const header1 = it.next().?;

--- a/src/apple_pie.zig
+++ b/src/apple_pie.zig
@@ -5,7 +5,6 @@ pub const MimeType = @import("mime_type.zig");
 pub const router = @import("router.zig");
 pub usingnamespace @import("server.zig");
 
-comptime {
-    const std = @import("std");
-    std.testing.refAllDecls(@This());
+test {
+    @import("std").testing.refAllDecls(@This());
 }

--- a/src/apple_pie.zig
+++ b/src/apple_pie.zig
@@ -1,4 +1,4 @@
-pub const Request = @import("request.zig").Request;
+pub const Request = @import("Request.zig");
 pub const Response = @import("response.zig").Response;
 pub const FileServer = @import("fs.zig").FileServer;
 pub const MimeType = @import("mime_type.zig");

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -49,7 +49,7 @@ pub fn serve(response: *Response, request: Request) ServeError!void {
     std.debug.assert(initialized);
     const index = "index.html";
     var buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
-    var path = url.sanitize(request.context.url.path, &buffer);
+    var path = url.sanitize(request.path(), &buffer);
 
     if (std.mem.endsWith(u8, path, index)) {
         return localRedirect(response, request, "./", alloc);
@@ -72,7 +72,7 @@ pub fn serve(response: *Response, request: Request) ServeError!void {
     };
     defer file.close();
 
-    serveFile(response, request.context.url.path, file) catch |err| switch (err) {
+    serveFile(response, request.path(), file) catch |err| switch (err) {
         error.NotAFile => return response.notFound(),
         else => return err,
     };

--- a/src/mime_type.zig
+++ b/src/mime_type.zig
@@ -29,7 +29,7 @@ pub const MimeType = struct {
                 return MimeType{ .text = mapping.mime_type };
             }
         }
-        return MimeType{ .text = "application/octet-stream" };
+        return MimeType{ .text = "text/plain;charset=UTF-8" };
     }
 
     /// Returns the MimeType based on the file name

--- a/src/response.zig
+++ b/src/response.zig
@@ -144,7 +144,7 @@ pub const Response = struct {
     /// Note that this will complete the response and any further writes are illegal.
     pub fn writeHeader(self: *Response, status_code: StatusCode) Error!void {
         self.status_code = status_code;
-        try self.body.print("{s}", .{self.status_code.toString()});
+        try self.body.print("{s}\n", .{self.status_code.toString()});
         try self.flush();
     }
 

--- a/src/response.zig
+++ b/src/response.zig
@@ -1,3 +1,8 @@
+//! Handles the logic for sending a response to the client.
+//! Although it provides access to the direct stream,
+//! it is suggested to use the helper methods such as `writer()` to ensure
+//! for correct handling.
+
 const std = @import("std");
 const net = std.net;
 const Allocator = std.mem.Allocator;

--- a/src/router.zig
+++ b/src/router.zig
@@ -1,6 +1,13 @@
+//! Comptime Trie based router that creates a Trie
+//! for each HTTP method and a catch-all one that works
+//! on any method, granted it has a handler defined.
+//! The router parses params into a type defined as the 3rd
+//! argument of the handler function. Any other argument is ignored for parsing.
+//! multi-params require a struct as argument type.
+
 const std = @import("std");
 const trie = @import("trie.zig");
-const Request = @import("request.zig").Request;
+const Request = @import("Request.zig");
 const Response = @import("response.zig").Response;
 const RequestHandler = @import("server.zig").RequestHandler;
 
@@ -79,10 +86,10 @@ pub fn router(comptime routes: []const Route) RequestHandler {
         }
 
         fn serve(response: *Response, request: Request) !void {
-            switch (trees[@enumToInt(request.method)].get(request.url.path)) {
+            switch (trees[@enumToInt(request.context.method)].get(request.context.url.path)) {
                 .none => {
                     // if nothing was found for current method, try the wildcard
-                    switch (trees[9].get(request.url.path)) {
+                    switch (trees[9].get(request.context.url.path)) {
                         .none => return response.notFound(),
                         .static => |index| {
                             inline for (routes) |route, i|

--- a/src/router.zig
+++ b/src/router.zig
@@ -86,10 +86,10 @@ pub fn router(comptime routes: []const Route) RequestHandler {
         }
 
         fn serve(response: *Response, request: Request) !void {
-            switch (trees[@enumToInt(request.context.method)].get(request.context.url.path)) {
+            switch (trees[@enumToInt(request.method())].get(request.path())) {
                 .none => {
                     // if nothing was found for current method, try the wildcard
-                    switch (trees[9].get(request.context.url.path)) {
+                    switch (trees[9].get(request.path())) {
                         .none => return response.notFound(),
                         .static => |index| {
                             inline for (routes) |route, i|

--- a/src/server.zig
+++ b/src/server.zig
@@ -164,7 +164,9 @@ fn ClientFn(comptime handler: RequestHandler) type {
                 };
 
                 var buffer: [max_request_size]u8 = undefined;
+                var body_read = false;
                 const parsed_request = Request.parse(
+                    &body_read,
                     stack_allocator.get(),
                     &std.io.bufferedReader(self.stream.reader()),
                     &buffer,

--- a/src/server.zig
+++ b/src/server.zig
@@ -245,5 +245,5 @@ test "Basic server test" {
     const index = std.mem.indexOf(u8, buf[0..len], "\r\n\r\n") orelse return error.Unexpected;
 
     const answer = buf[index + 4 .. len];
-    std.testing.expectEqualStrings(test_message, answer);
+    try std.testing.expectEqualStrings(test_message, answer);
 }

--- a/src/url.zig
+++ b/src/url.zig
@@ -118,8 +118,8 @@ fn unescape(allocator: *Allocator, value: []const u8) QueryError![]const u8 {
 
 /// Sanitizes the given `path` by removing '..' etc.
 /// This returns a slice from a static buffer and therefore requires no allocations
-pub fn sanitize(path: []const u8) []const u8 {
-    var buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+pub fn sanitize(path: []const u8, buffer: []u8) []const u8 {
+    // var buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
 
     if (path.len == 0) {
         buffer[0] = '.';
@@ -128,8 +128,8 @@ pub fn sanitize(path: []const u8) []const u8 {
 
     const rooted = path[0] == '/';
     const len = path.len;
-    std.mem.copy(u8, &buffer, path);
-    var out = BufferUtil.init(&buffer, path);
+    std.mem.copy(u8, buffer, path);
+    var out = BufferUtil.init(buffer, path);
 
     var i: usize = 0;
     var dot: usize = 0;

--- a/src/url.zig
+++ b/src/url.zig
@@ -235,7 +235,7 @@ test "Basic raw query" {
     const path = "/example?name=value";
     const url: Url = Url.init(path);
 
-    testing.expectEqualSlices(u8, "?name=value", url.raw_query);
+    try testing.expectEqualSlices(u8, "?name=value", url.raw_query);
 }
 
 test "Retrieve query parameters" {
@@ -244,8 +244,8 @@ test "Retrieve query parameters" {
 
     var query_params = try url.queryParameters(testing.allocator);
     defer query_params.deinit();
-    testing.expect(query_params.contains("name"));
-    testing.expectEqualStrings("value", query_params.get("name") orelse " ");
+    try testing.expect(query_params.contains("name"));
+    try testing.expectEqualStrings("value", query_params.get("name") orelse " ");
 }
 
 test "Sanitize paths" {
@@ -300,6 +300,7 @@ test "Sanitize paths" {
     };
 
     inline for (cases) |case| {
-        testing.expectEqualStrings(case.expected, sanitize(case.input));
+        var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+        try testing.expectEqualStrings(case.expected, sanitize(case.input, &buf));
     }
 }


### PR DESCRIPTION
Restructured the parser code to make it easier to read and maintain.
This new structure also allows for the user to decide whether to use a buffer
or to allocate the body. If the body is never read, the server will skip it at the end of the request.
(Only when keep-alive is active).

All context of the parsed request is now saved in a seperate structure: `context` of type `Context`.
This provides a cleaner seperation between the logic of a `Request` and the data that was parsed.

The new structure also sets us up to correctly handle chunked bodies.

Fixes #18 
