### PR TITLE
Implement 'chunked' transfer encoding

### DIFF
--- a/src/response.zig
+++ b/src/response.zig
@@ -149,6 +149,8 @@ pub const Response = struct {
     /// Note that this will complete the response and any further writes are illegal.
     pub fn writeHeader(self: *Response, status_code: StatusCode) Error!void {
         self.status_code = status_code;
+        // reset body to wipe any user written data
+        self.body.context.items.len = 0;
         try self.body.print("{s}\n", .{self.status_code.toString()});
         try self.flush();
     }

--- a/src/server.zig
+++ b/src/server.zig
@@ -181,7 +181,10 @@ fn ClientFn(comptime handler: RequestHandler) type {
                     return response.writeHeader(.bad_request);
                 }
 
-                try handler(&response, parsed_request);
+                handler(&response, parsed_request) catch |err| {
+                    try response.writeHeader(.bad_request);
+                    return err;
+                };
 
                 if (!response.is_flushed) try response.flush(); // ensure data is flushed
                 if (parsed_request.context.should_close) return; // close connection


### PR DESCRIPTION
This reader reads from a `std.io.Reader` type and returns
each chunk it parses. It also validates it on correctness.
The internal buffer that is provided is rewritten on each call on `next`
therefore users must ensure to copy the data before saving it.

Todo:
- [x] Implement a reader that supports reading/parsing a chunked body.
- [x] Allow users to call the chunked reader.
- [x] Implement a way to skip (read) the chunked body to make sure the reader is 'empty' before reading the next request.

Fixes #32 