### PR TITLE
Add Content-Length Header field if the response is empty

### DIFF
--- a/src/response.zig
+++ b/src/response.zig
@@ -182,7 +182,7 @@ pub const Response = struct {
         }
 
         // If user has not set content-length, we add it calculated by the length of the body
-        if (body.len > 0 and !self.headers.contains("Content-Length")) {
+        if (!self.headers.contains("Content-Length")) {
             try socket.print("Content-Length: {d}\r\n", .{body.len});
         }
 


### PR DESCRIPTION
According to the [spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html), a `Content-Length` of zero is allowed. Furthermore, according to the [spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4), when not supplying `Content-Length`, the server must close the connection in order to signal the end of the response, which is not always the case (as keep-alive may be enabled). So the best solution would be to include the `Content-Length` header even if the response is empty.