### PR TITLE
trie: don't assume data is non null when path is /

### DIFF
--- a/src/router.zig
+++ b/src/router.zig
@@ -200,3 +200,7 @@ pub fn trace(comptime path: []const u8, comptime handler: anytype) Route {
 pub fn any(comptime path: []const u8, comptime handler: anytype) Route {
     return handle(.any, path, handler);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/trie.zig
+++ b/src/trie.zig
@@ -101,7 +101,11 @@ pub fn Trie(comptime T: type) type {
         /// If a colon is found, it will add the path piece onto the param list
         pub fn get(self: *Self, path: []const u8) Result {
             if (path.len == 1) {
-                return .{ .static = self.root.data.? };
+                if (self.root.data) |data| {
+                    return .{ .static = data };
+                } else {
+                    return .none;
+                }
             }
 
             var params: [max_params]Entry = undefined;

--- a/src/trie.zig
+++ b/src/trie.zig
@@ -176,22 +176,22 @@ test "Insert and retrieve" {
     const res6 = trie.get("/topics/5/");
     const res7 = trie.get("/bar");
 
-    std.testing.expectEqual(@as(u32, 1), res.with_params.data);
-    std.testing.expectEqual(@as(u32, 2), res2.with_params.data);
-    std.testing.expectEqual(@as(u32, 2), res2a.with_params.data);
-    std.testing.expectEqual(@as(u32, 3), res3.with_params.data);
-    std.testing.expect(res4 == .none);
-    std.testing.expectEqual(@as(u32, 4), res5.with_params.data);
-    std.testing.expectEqual(@as(u32, 4), res6.with_params.data);
-    std.testing.expectEqual(@as(u32, 5), res7.static);
+    try std.testing.expectEqual(@as(u32, 1), res.with_params.data);
+    try std.testing.expectEqual(@as(u32, 2), res2.with_params.data);
+    try std.testing.expectEqual(@as(u32, 2), res2a.with_params.data);
+    try std.testing.expectEqual(@as(u32, 3), res3.with_params.data);
+    try std.testing.expect(res4 == .none);
+    try std.testing.expectEqual(@as(u32, 4), res5.with_params.data);
+    try std.testing.expectEqual(@as(u32, 4), res6.with_params.data);
+    try std.testing.expectEqual(@as(u32, 5), res7.static);
 
-    std.testing.expectEqualStrings("5", res.with_params.params[0].value);
-    std.testing.expectEqualStrings("bla", res2.with_params.params[0].value);
-    std.testing.expectEqualStrings("bla/bla", res2a.with_params.params[0].value);
-    std.testing.expectEqualStrings("25", res3.with_params.params[0].value);
-    std.testing.expectEqualStrings("20", res3.with_params.params[1].value);
-    std.testing.expectEqualStrings("5", res5.with_params.params[0].value);
-    std.testing.expectEqualStrings("foo", res5.with_params.params[1].value);
+    try std.testing.expectEqualStrings("5", res.with_params.params[0].value);
+    try std.testing.expectEqualStrings("bla", res2.with_params.params[0].value);
+    try std.testing.expectEqualStrings("bla/bla", res2a.with_params.params[0].value);
+    try std.testing.expectEqualStrings("25", res3.with_params.params[0].value);
+    try std.testing.expectEqualStrings("20", res3.with_params.params[1].value);
+    try std.testing.expectEqualStrings("5", res5.with_params.params[0].value);
+    try std.testing.expectEqualStrings("foo", res5.with_params.params[1].value);
 }
 
 test "Insert and retrieve paths with same prefix" {
@@ -208,12 +208,12 @@ test "Insert and retrieve paths with same prefix" {
     const res5 = trie.get("/foo");
     const res6 = trie.get("/api/api/events");
 
-    std.testing.expectEqual(@as(u32, 1), res.static);
-    std.testing.expectEqual(@as(u32, 2), res2.static);
-    std.testing.expectEqual(@as(u32, 3), res3.static);
-    std.testing.expectEqual(@as(u32, 4), res4.with_params.data);
-    std.testing.expect(res5 == .none);
-    std.testing.expect(res6 == .none);
+    try std.testing.expectEqual(@as(u32, 1), res.static);
+    try std.testing.expectEqual(@as(u32, 2), res2.static);
+    try std.testing.expectEqual(@as(u32, 3), res3.static);
+    try std.testing.expectEqual(@as(u32, 4), res4.with_params.data);
+    try std.testing.expect(res5 == .none);
+    try std.testing.expect(res6 == .none);
 
-    std.testing.expectEqualStrings("1337", res4.with_params.params[0].value);
+    try std.testing.expectEqualStrings("1337", res4.with_params.params[0].value);
 }

--- a/src/trie.zig
+++ b/src/trie.zig
@@ -217,3 +217,11 @@ test "Insert and retrieve paths with same prefix" {
 
     try std.testing.expectEqualStrings("1337", res4.with_params.params[0].value);
 }
+
+test "Get root" {
+    comptime var trie = Trie(u32){};
+    comptime trie.insert("/api", 1);
+
+    const res = trie.get("/");
+    try std.testing.expect(res == .none);
+}


### PR DESCRIPTION
Fixes a panic when no handler for / is defined for a particular trie.

Closes #65.