### PR TITLE
Export Headers

### DIFF
--- a/src/apple_pie.zig
+++ b/src/apple_pie.zig
@@ -1,5 +1,7 @@
 pub const Request = @import("Request.zig");
-pub const Response = @import("response.zig").Response;
+const resp = @import("response.zig");
+pub const Response = resp.Response;
+pub const Headers = resp.Headers;
 pub const FileServer = @import("fs.zig").FileServer;
 pub const MimeType = @import("mime_type.zig");
 pub const router = @import("router.zig");


### PR DESCRIPTION
Better than having to go into code to find out `Headers` is an alias for `std.StringArrayHashMap([]const u8)`, then use that (and hope it doesn't change in the future).