### PR TITLE
Get params from handler fn

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -42,7 +42,7 @@ pub fn build(b: *Builder) void {
         var example = b.addExecutable(opt, example_file);
         example.addPackage(.{
             .name = "apple_pie",
-            .path = .{ .path = "src/apple_pie.zig" },
+            .source = .{ .path = "src/apple_pie.zig" },
         });
         example.setBuildMode(mode);
         example.install();

--- a/examples/router.zig
+++ b/examples/router.zig
@@ -77,8 +77,11 @@ fn serveFs(ctx: *Context, resp: *http.Response, req: http.Request) !void {
 }
 
 /// Shows the post number and message text
-fn messages(ctx: *Context, resp: *http.Response, req: http.Request, post: usize, message: []const u8) !void {
+fn messages(ctx: *Context, resp: *http.Response, req: http.Request, captures: struct { post: []const u8, message: []const u8 }) !void {
     _ = ctx;
     _ = req;
-    try resp.writer().print("Post {d}, message: '{s}'\n", .{ post, message });
+    const post = std.fmt.parseInt(usize, captures.post, 10) catch {
+        return resp.notFound();
+    };
+    try resp.writer().print("Post {d}, message: '{s}'\n", .{ post, captures.message });
 }

--- a/examples/router.zig
+++ b/examples/router.zig
@@ -18,18 +18,19 @@ pub fn main() !void {
     defer fs.deinit();
 
     var context: Context = .{ .last_route = null };
+    const builder = router.Builder(*Context);
 
     try http.listenAndServe(
         allocator,
         try std.net.Address.parseIp("127.0.0.1", 8080),
         &context,
         comptime router.Router(*Context, &.{
-            .{ .method = .get, .path = "/", .handler = router.wrap(*Context, index) },
-            .{ .method = .get, .path = "/headers", .handler = router.wrap(*Context, headers) },
-            .{ .method = .get, .path = "/files/*", .handler = router.wrap(*Context, serveFs) },
-            .{ .method = .get, .path = "/hello/:name", .handler = router.wrap(*Context, hello) },
-            .{ .method = .get, .path = "/route", .handler = router.wrap(*Context, route) },
-            .{ .method = .get, .path = "/posts/:post/messages/:message", .handler = router.wrap(*Context, messages) },
+            builder.get("/", index),
+            builder.get("/headers", headers),
+            builder.get("/files/*", serveFs),
+            builder.get("/hello/:name", hello),
+            builder.get("/route", route),
+            builder.get("/posts/:post/messages/:message", messages),
         }),
     );
 }

--- a/src/router.zig
+++ b/src/router.zig
@@ -104,12 +104,9 @@ pub fn wrap(comptime Context: type, comptime handler: anytype) Route(Context).Ha
     if (function_info.is_var_args)
         @compileError("Cannot create handler wrapper for variadic function");
 
-    if (function_info.args[0].arg_type.? != Context)
-        @compileError("Argument 0 of a HandlerFn must be Context");
-    if (function_info.args[1].arg_type.? != *Response)
-        @compileError("Argument 1 of a HandlerFn must be *Response");
-    if (function_info.args[2].arg_type.? != Request)
-        @compileError("Argument 2 of a HandlerFn must be Request");
+    assertIsType("Expected first argument of handler to be", Context, function_info.args[0].arg_type.?);
+    assertIsType("Expected first argument of handler to be", *Response, function_info.args[1].arg_type.?);
+    assertIsType("Expected first argument of handler to be", Request, function_info.args[2].arg_type.?);
 
     const capture_args_info = function_info.args[3..];
     var capture_arg_types: [capture_args_info.len]type = undefined;
@@ -149,6 +146,11 @@ pub fn wrap(comptime Context: type, comptime handler: anytype) Route(Context).Ha
     };
 
     return X.wrapper;
+}
+
+fn assertIsType(comptime text: []const u8, expected: type, actual: type) void {
+    if (actual != expected)
+        @compileError(text ++ " " ++ @typeName(expected) ++ ", but found type " ++ @typeName(actual) ++ " instead");
 }
 
 /// Creates a builder namespace, generic over the given `Context`

--- a/src/router.zig
+++ b/src/router.zig
@@ -35,23 +35,6 @@ pub fn Router(comptime Context: type, comptime routes: []const Route(Context)) R
     inline for (trees) |*t| t.* = trie.Trie(u8){};
 
     inline for (routes) |r, i| {
-        if (@typeInfo(@TypeOf(r.handler)) != .Fn) @compileError("Handler must be a function");
-
-        const args = @typeInfo(@TypeOf(r.handler)).Fn.args;
-
-        if (args.len < 3) {
-            @compileError("Handler must have atleast 3 arguments");
-        }
-        if (args[0].arg_type.? != Context) {
-            @compileError("Expected type '" ++ @typeName(Context) ++ "', but found type '" ++ @typeName(args[0].arg_type.?) ++ "'");
-        }
-        if (args[1].arg_type.? != *Response) {
-            @compileError("Second parameter must be of type " ++ @typeName(*Response));
-        }
-        if (args[2].arg_type.? != Request) {
-            @compileError("Third parameter must be of type " ++ @typeName(Request));
-        }
-
         trees[@enumToInt(r.method)].insert(r.path, i);
     }
 

--- a/src/router.zig
+++ b/src/router.zig
@@ -87,44 +87,72 @@ pub fn wrap(comptime Context: type, comptime handler: anytype) Route(Context).Ha
     if (function_info.is_var_args)
         @compileError("Cannot create handler wrapper for variadic function");
 
+    if (function_info.args.len < 3)
+        @compileError("Expected at least 3 args in Handler function; (" ++ @typeName(Context) ++ ", " ++ @typeName(*Response) ++ ", " ++ @typeName(Request) ++ ")]");
+
     assertIsType("Expected first argument of handler to be", Context, function_info.args[0].arg_type.?);
     assertIsType("Expected second argument of handler to be", *Response, function_info.args[1].arg_type.?);
     assertIsType("Expected third argument of handler to be", Request, function_info.args[2].arg_type.?);
 
-    const capture_args_info = function_info.args[3..];
-    var capture_arg_types: [capture_args_info.len]type = undefined;
-    for (capture_args_info) |arg, i| {
-        capture_arg_types[i] = arg.arg_type.?;
-    }
-    const CaptureArgs = std.meta.Tuple(&capture_arg_types);
+    const CapturesExpected = union(enum) {
+        none,
+        one_string,
+        struct_fields: usize,
+    };
+
+    const expected_captures: CapturesExpected = calc_captures_expected: {
+        if (function_info.args.len < 4) {
+            break :calc_captures_expected .none;
+        }
+
+        switch (function_info.args[3].arg_type.?) {
+            []const u8 => break :calc_captures_expected .one_string,
+
+            else => |ArgType| if (@typeInfo(ArgType) == .Struct) {
+                const struct_info = @typeInfo(ArgType).Struct;
+                inline for (struct_info.fields) |field| {
+                    assertIsType("Expected all fields of capture to be", []const u8, field.field_type);
+                }
+                break :calc_captures_expected .{ .struct_fields = struct_info.fields.len };
+            } else {
+                @compileError("Unsupported type `" ++ @typeName(ArgType) ++ "`. Must be `[]const u8` or a struct whose fields are `[]const u8`.");
+            },
+        }
+    };
 
     const X = struct {
         fn wrapper(ctx: Context, res: *Response, req: Request, params: []const trie.Entry) anyerror!void {
-            var capture_args: CaptureArgs = undefined;
+            switch (expected_captures) {
+                .none => {
+                    std.debug.assert(params.len == 0);
+                    return handler(ctx, res, req);
+                },
+                .one_string => {
+                    std.debug.assert(params.len == 1);
+                    return handler(ctx, res, req, params[0].value);
+                },
+                .struct_fields => |num_fields_expected| {
+                    std.debug.assert(params.len == num_fields_expected);
 
-            std.debug.assert(params.len == capture_args.len); // Number of captures must equal the number of extra parameters in the Handler function
+                    const CaptureStruct = function_info.args[3].arg_type.?;
+                    var captures: CaptureStruct = undefined;
 
-            if (capture_args.len == 0) return handler(ctx, res, req);
+                    for (params) |param| {
+                        // Using a variable here instead of something like `continue :params_loop` because that causes the compiler to crash with exit code 11.
+                        var matched_a_field = false;
+                        inline for (@typeInfo(CaptureStruct).Struct.fields) |field| {
+                            if (std.mem.eql(u8, param.key, field.name)) {
+                                @field(captures, field.name) = param.value;
+                                matched_a_field = true;
+                            }
+                        }
+                        if (!matched_a_field)
+                            std.debug.panic("Unexpected capture \"{}\", no such field in {s}", .{ std.zig.fmtEscapes(param.key), @typeName(CaptureStruct) });
+                    }
 
-            comptime var arg_index = 0;
-            inline while (arg_index < capture_args.len) : (arg_index += 1) {
-                capture_args[arg_index] = switch (@TypeOf(capture_args[arg_index])) {
-                    []const u8 => params[arg_index].value,
-                    //?[]const u8 => if (params.len > 0) params[0].value else null,
-                    else => |ArgType| switch (@typeInfo(ArgType)) {
-                        .Int => std.fmt.parseInt(ArgType, params[arg_index].value, 10) catch {
-                            return res.notFound();
-                        },
-                        .Optional => |child| if (@typeInfo(child) == .Int)
-                            std.fmt.parseInt(ArgType, params[arg_index].value, 10) catch null
-                        else
-                            @compileError("Unsupported optional type " ++ @typeName(child)),
-                        else => @compileError("Unsupported type " ++ @typeName(ArgType)),
-                    },
-                };
+                    return handler(ctx, res, req, captures);
+                },
             }
-
-            return @call(.{}, handler, .{ ctx, res, req } ++ capture_args);
         }
     };
 

--- a/src/router.zig
+++ b/src/router.zig
@@ -151,6 +151,95 @@ pub fn wrap(comptime Context: type, comptime handler: anytype) Route(Context).Ha
     return X.wrapper;
 }
 
+/// Creates a builder namespace, generic over the given `Context`
+/// This makes it easy to create the routers without having to passing
+/// a lot of the types.
+pub fn Builder(comptime Context: type) type {
+    return struct {
+        const Handler = Route(Context).Handler;
+
+        pub fn get(path: []const u8, comptime handlerFn: anytype) Route(Context) {
+            return Route(Context){
+                .method = .get,
+                .path = path,
+                .handler = wrap(Context, handlerFn),
+            };
+        }
+
+        pub fn post(path: []const u8, comptime handlerFn: anytype) Route(Context) {
+            return Route(Context){
+                .method = .post,
+                .path = path,
+                .handler = wrap(Context, handlerFn),
+            };
+        }
+
+        pub fn patch(path: []const u8, comptime handlerFn: anytype) Route(Context) {
+            return Route(Context){
+                .method = .patch,
+                .path = path,
+                .handler = wrap(Context, handlerFn),
+            };
+        }
+
+        pub fn put(path: []const u8, comptime handlerFn: anytype) Route(Context) {
+            return Route(Context){
+                .method = .put,
+                .path = path,
+                .handler = wrap(Context, handlerFn),
+            };
+        }
+
+        pub fn any(path: []const u8, comptime handlerFn: anytype) Route(Context) {
+            return Route(Context){
+                .method = .any,
+                .path = path,
+                .handler = wrap(Context, handlerFn),
+            };
+        }
+
+        pub fn head(path: []const u8, comptime handlerFn: anytype) Route(Context) {
+            return Route(Context){
+                .method = .head,
+                .path = path,
+                .handler = wrap(Context, handlerFn),
+            };
+        }
+
+        pub fn delete(path: []const u8, comptime handlerFn: anytype) Route(Context) {
+            return Route(Context){
+                .method = .delete,
+                .path = path,
+                .handler = wrap(Context, handlerFn),
+            };
+        }
+
+        pub fn connect(path: []const u8, comptime handlerFn: anytype) Route(Context) {
+            return Route(Context){
+                .method = .connect,
+                .path = path,
+                .handler = wrap(Context, handlerFn),
+            };
+        }
+
+        pub fn options(path: []const u8, comptime handlerFn: anytype) Route(Context) {
+            return Route(Context){
+                .method = .options,
+                .path = path,
+                .handler = wrap(Context, handlerFn),
+            };
+        }
+
+        pub fn trace(path: []const u8, comptime handlerFn: anytype) Route(Context) {
+            return Route(Context){
+                .method = .trace,
+                .path = path,
+                .handler = wrap(Context, handlerFn),
+            };
+        }
+    };
+}
+
 test {
     std.testing.refAllDecls(@This());
 }

--- a/src/router.zig
+++ b/src/router.zig
@@ -11,18 +11,16 @@ const Request = @import("Request.zig");
 const Response = @import("response.zig").Response;
 const RequestHandler = @import("server.zig").RequestHandler;
 
+pub const Entry = trie.Entry;
+
 /// Route defines the path, method and how to parse such path
 /// into a type that the handler can accept.
 pub fn Route(comptime Context: type) type {
     return struct {
         /// Path by which the route is triggered
         path: []const u8,
-        /// The type the path captures will be transformed into
-        /// This type will be passed as an '*const anyopaque' as the final argument
-        /// to the route handler.
-        capture_type: ?type = null,
         /// The handler function that will be called when triggered
-        handler: fn handle(Context, *Response, Request, ?*const anyopaque) anyerror!void,
+        handler: fn handle(Context, *Response, Request, params: []const Entry) anyerror!void,
         /// http method
         method: Request.Method,
     };
@@ -58,48 +56,6 @@ pub fn Router(comptime Context: type, comptime routes: []const Route(Context)) R
     return struct {
         const Self = @This();
 
-        fn handle(comptime route: Route(Context), params: []const trie.Entry, ctx: Context, res: *Response, req: Request) !void {
-            if (route.capture_type == null) return route.handler(ctx, res, req, null);
-            const ArgType = route.capture_type.?;
-
-            const param: ArgType = switch (ArgType) {
-                []const u8 => if (params.len > 0) params[0].value else &[_]u8{},
-                ?[]const u8 => if (params.len > 0) params[0].value else null,
-                else => switch (@typeInfo(ArgType)) {
-                    .Struct => |info| blk: {
-                        var new_struct: ArgType = undefined;
-                        inline for (info.fields) |field| {
-                            for (params) |p| {
-                                if (std.mem.eql(u8, field.name, p.key)) {
-                                    const FieldType = @TypeOf(@field(new_struct, field.name));
-
-                                    @field(new_struct, field.name) = switch (FieldType) {
-                                        []const u8, ?[]const u8 => p.value,
-                                        else => switch (@typeInfo(FieldType)) {
-                                            .Int => std.fmt.parseInt(FieldType, p.value, 10) catch 0,
-                                            .Optional => |child| if (@typeInfo(child) == .Int)
-                                                std.fmt.parseInt(FieldType, p.value, 10) catch null
-                                            else
-                                                @compileError("Unsupported optional type " ++ @typeName(child)),
-                                            else => @compileError("Unsupported type " ++ @typeName(FieldType)),
-                                        },
-                                    };
-                                }
-                            }
-                        }
-                        break :blk new_struct;
-                    },
-                    .Int => std.fmt.parseInt(ArgType, params[0].value, 10) catch 0,
-                    .Optional => |child| if (@typeInfo(child) == .Int)
-                        std.fmt.parseInt(ArgType, params[0].value, 10) catch null
-                    else
-                        @compileError("Unsupported optional type " ++ @typeName(child)),
-                    else => @compileError("Unsupported type " ++ @typeName(ArgType)),
-                },
-            };
-            return route.handler(ctx, res, req, @ptrCast(?*const anyopaque, &param));
-        }
-
         pub fn serve(context: Context, response: *Response, request: Request) !void {
             switch (trees[@enumToInt(request.method())].get(request.path())) {
                 .none => {
@@ -108,100 +64,30 @@ pub fn Router(comptime Context: type, comptime routes: []const Route(Context)) R
                         .none => return response.notFound(),
                         .static => |index| {
                             inline for (routes) |route, i|
-                                if (index == i) return Self.handle(route, &.{}, context, response, request);
+                                if (index == i) return route.handler(context, response, request, &.{});
                         },
                         .with_params => |object| {
                             inline for (routes) |route, i| {
                                 if (object.data == i)
-                                    return Self.handle(route, object.params[0..object.param_count], context, response, request);
+                                    return route.handler(context, response, request, object.params[0..object.param_count]);
                             }
                         },
                     }
                 },
                 .static => |index| {
                     inline for (routes) |route, i| {
-                        if (index == i) return Self.handle(route, &.{}, context, response, request);
+                        if (index == i) return route.handler(context, response, request, &.{});
                     }
                 },
                 .with_params => |object| {
                     inline for (routes) |route, i| {
                         if (object.data == i)
-                            return Self.handle(route, object.params[0..object.param_count], context, response, request);
+                            return route.handler(context, response, request, object.params[0..object.param_count]);
                     }
                 },
             }
         }
     }.serve;
-}
-
-/// Creates a builder namespace, generic over the given `Context`
-/// This makes it easy to create the routers without having to passing
-/// a lot of the types.
-pub fn Builder(comptime Context: type) type {
-    return struct {
-        /// The generic handler type that all routes must match
-        pub const HandlerType = fn (Context, *Response, Request, ?*const anyopaque) anyerror!void;
-
-        /// Creates a new `Route` for the given HTTP Method that will be
-        /// triggered based on its path conditions
-        ///
-        /// When the path contains parameters such as ':<name>' it will be captured
-        /// and parsed into the type given as `capture_type`.
-        pub fn basicRoute(
-            comptime method: Request.Method,
-            comptime path: []const u8,
-            comptime CaptureType: ?type,
-            comptime handler: HandlerType,
-        ) Route(Context) {
-            return .{
-                .method = method,
-                .path = path,
-                .capture_type = CaptureType,
-                .handler = handler,
-            };
-        }
-
-        /// Shorthand function to create a `Route` where method is 'GET'
-        pub fn get(comptime path: []const u8, comptime CaptureType: ?type, comptime handler: HandlerType) Route(Context) {
-            return basicRoute(.get, path, CaptureType, handler);
-        }
-        /// Shorthand function to create a `Route` where method is 'POST'
-        pub fn post(comptime path: []const u8, comptime CaptureType: ?type, comptime handler: HandlerType) Route(Context) {
-            return basicRoute(.post, path, CaptureType, handler);
-        }
-        /// Shorthand function to create a `Route` where method is 'PATCH'
-        pub fn patch(comptime path: []const u8, comptime CaptureType: ?type, comptime handler: HandlerType) Route(Context) {
-            return basicRoute(.patch, path, CaptureType, handler);
-        }
-        /// Shorthand function to create a `Route` where method is 'PUT'
-        pub fn put(comptime path: []const u8, comptime CaptureType: ?type, comptime handler: HandlerType) Route(Context) {
-            return basicRoute(.put, path, CaptureType, handler);
-        }
-        /// Shorthand function to create a `Route` which matches with any method
-        pub fn any(comptime path: []const u8, comptime CaptureType: ?type, comptime handler: HandlerType) Route(Context) {
-            return basicRoute(.any, path, CaptureType, handler);
-        }
-        /// Shorthand function to create a `Route` where method is 'HEAD'
-        pub fn head(comptime path: []const u8, comptime CaptureType: ?type, comptime handler: HandlerType) Route(Context) {
-            return basicRoute(.head, path, CaptureType, handler);
-        }
-        /// Shorthand function to create a `Route` where method is 'DELETE'
-        pub fn delete(comptime path: []const u8, comptime CaptureType: ?type, comptime handler: HandlerType) Route(Context) {
-            return basicRoute(.delete, path, CaptureType, handler);
-        }
-        /// Shorthand function to create a `Route` where method is 'CONNECT'
-        pub fn connect(comptime path: []const u8, comptime CaptureType: ?type, comptime handler: HandlerType) Route(Context) {
-            return basicRoute(.connect, path, CaptureType, handler);
-        }
-        /// Shorthand function to create a `Route` where method is 'OPTIONS'
-        pub fn options(comptime path: []const u8, comptime CaptureType: ?type, comptime handler: HandlerType) Route(Context) {
-            return basicRoute(.options, path, CaptureType, handler);
-        }
-        /// Shorthand function to create a `Route` where method is 'TRACE'
-        pub fn trace(comptime path: []const u8, comptime CaptureType: ?type, comptime handler: HandlerType) Route(Context) {
-            return basicRoute(.trace, path, CaptureType, handler);
-        }
-    };
 }
 
 test {

--- a/src/router.zig
+++ b/src/router.zig
@@ -88,8 +88,8 @@ pub fn wrap(comptime Context: type, comptime handler: anytype) Route(Context).Ha
         @compileError("Cannot create handler wrapper for variadic function");
 
     assertIsType("Expected first argument of handler to be", Context, function_info.args[0].arg_type.?);
-    assertIsType("Expected first argument of handler to be", *Response, function_info.args[1].arg_type.?);
-    assertIsType("Expected first argument of handler to be", Request, function_info.args[2].arg_type.?);
+    assertIsType("Expected second argument of handler to be", *Response, function_info.args[1].arg_type.?);
+    assertIsType("Expected third argument of handler to be", Request, function_info.args[2].arg_type.?);
 
     const capture_args_info = function_info.args[3..];
     var capture_arg_types: [capture_args_info.len]type = undefined;


### PR DESCRIPTION
- Params are handled by order, not by name. Don't think there is a way to get parameter names.
- Currently treats each parameter after the first three as capture arguments. Might want to only pull the 4th argument, and then use a struct?

Would close #79 