### PR TITLE
fix index redirect content type

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -87,7 +87,7 @@ pub fn serve(ctx: void, response: *Response, request: Request) ServeError!void {
     };
     defer file.close();
 
-    serveFile(response, request.path(), file) catch |err| switch (err) {
+    serveFile(response, new_path, file) catch |err| switch (err) {
         error.NotAFile => return response.notFound(),
         else => return err,
     };


### PR DESCRIPTION
Hey there! First of all, I want to say thank you for the library, it's been very useful.

This PR is addressing a particular issue I've been having with index files, related to https://github.com/Luukdegram/apple_pie/pull/81.

The index file is showing up, but it's being sent as a plaintext file. This is happening because when the server sees "index.html", it creates a local redirect to ./ - when the server uses this path to serve the file, it doesn't find the html expension and therefore serves it as plaintext.

This PR passes the path used to open the file (which has been corrected from ./ to index.html) instead of the request path to fix the issue.

