### PR TITLE
Remove function names from type definitions

### DIFF
--- a/src/router.zig
+++ b/src/router.zig
@@ -24,7 +24,7 @@ pub fn Route(comptime Context: type) type {
         /// http method
         method: Request.Method,
 
-        const Handler = fn handle(Context, *Response, Request, params: []const Entry) anyerror!void;
+        const Handler = fn (Context, *Response, Request, params: []const Entry) anyerror!void;
     };
 }
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -17,7 +17,7 @@ const Queue = atomic.Queue;
 
 /// User API function signature of a request handler
 pub fn RequestHandler(comptime Context: type) type {
-    return fn handle(Context, *Response, Request) anyerror!void;
+    return fn (Context, *Response, Request) anyerror!void;
 }
 
 /// Allows users to set the max buffer size before we allocate memory on the heap to store our data


### PR DESCRIPTION
This change was necessary to make `zig build example -Dexample=router` working again.